### PR TITLE
Allow hook nest

### DIFF
--- a/chainer_computational_cost/computational_cost_hook.py
+++ b/chainer_computational_cost/computational_cost_hook.py
@@ -84,6 +84,9 @@ class ComputationalCostHook(chainer.FunctionHook):
     _custom_cost_calculators = dict()
     max_digits = 10
 
+    # global counter to allow nested func
+    _hook_depth = 0
+
     def __init__(self, fma_1flop=True):
         self._fma_1flop = fma_1flop
         self._label_count = dict()
@@ -94,6 +97,16 @@ class ComputationalCostHook(chainer.FunctionHook):
         self._total_report = {
             'name': 'total', 'type': 'total'
         }
+        ComputationalCostHook._hook_depth += 1
+        self.name = "ComputationalCostHook-{}"\
+            .format(ComputationalCostHook._hook_depth)
+
+    def deleted(self, function=None):
+        """Callback function called by chainer when the hook lifetime has ended.
+
+        Please do not call it from anywhere in your code.
+        """
+        ComputationalCostHook._hook_depth -= 1
 
     def add_custom_cost_calculator(self, func_type, calculator):
         """Add custom cost calculator function.


### PR DESCRIPTION
Currently ComputationalCostHook doesn't work when it is nested, because its hook name reported to chainer is not changed and thus causing conflict.
This PR introduces internal global counter just to avoid the hook name conflict and allow user to enable multiple hooks.
This is useful when we want to analyze  computational cost of the whole network AND the part of the NN at the same time.