### PR TITLE
CI chainer v5 and chainer v4.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
   - "3.7-dev"
 env:
   - CHAINER_VERSION=3.5.0     # the last release of chainer v3
-  - CHAINER_VERSION=4.4.0     # the last release of chainer v4
-  - CHAINER_VERSION=v5.0.0rc1
+  - CHAINER_VERSION=4.5.0     # the last release of chainer v4
+  - CHAINER_VERSION=5.0.0
 install:
   - pip install chainer==$CHAINER_VERSION
   - pip install six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='chainer_computational_cost',
-      version='0.1.0',
+      version='0.1.1',
       description='Chainer theoretical computational cost estimator',
       author='Daichi SUZUO',
       author_email='suzuo@preferred.jp',


### PR DESCRIPTION
Travis python 3.7 is not yet officially available yet unfortunately..