### PR TITLE
Flake8 warns W605 violations in docstrings, which are false alarms

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore =
+  W605


### PR DESCRIPTION
```
./make_details_md.py:23:-256: W605 invalid escape sequence '\|'
./make_details_md.py:23:-251: W605 invalid escape sequence '\|'
./make_details_md.py:23:-143: W605 invalid escape sequence '\|'
./make_details_md.py:23:-138: W605 invalid escape sequence '\|'
./chainer_computational_cost/cost_calculators/pooling.py:26:-157: W605 invalid escape sequence '\|'
./chainer_computational_cost/cost_calculators/pooling.py:26:-152: W605 invalid escape sequence '\|'
./chainer_computational_cost/cost_calculators/pooling.py:26:-146: W605 invalid escape sequence '\m'
./chainer_computational_cost/cost_calculators/pooling.py:26:-131: W605 invalid escape sequence '\m'
./chainer_computational_cost/cost_calculators/pooling.py:26:-97: W605 invalid escape sequence '\|'
./chainer_computational_cost/cost_calculators/pooling.py:26:-92: W605 invalid escape sequence '\|'
./chainer_computational_cost/cost_calculators/pooling.py:26:-68: W605 invalid escape sequence '\|'
./chainer_computational_cost/cost_calculators/pooling.py:26:-63: W605 invalid escape sequence '\|'
./chainer_computational_cost/cost_calculators/pooling.py:61:-163: W605 invalid escape sequence '\|'
./chainer_computational_cost/cost_calculators/pooling.py:61:-158: W605 invalid escape sequence '\|'
...
```

c.f. https://github.com/biopython/biopython/commit/ec573b5869902035627f28ecae917d5a0db6fe1a