### PR TITLE
Update packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+dist: xenial
 env:
   - CHAINER_VERSION=4.5.0     # the last release of chainer v4
   - CHAINER_VERSION=5.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7-dev"
 env:
-  - CHAINER_VERSION=3.5.0     # the last release of chainer v3
   - CHAINER_VERSION=4.5.0     # the last release of chainer v4
-  - CHAINER_VERSION=5.0.0
+  - CHAINER_VERSION=5.2.0
+  - CHAINER_VERSION=6.0.0b2
 install:
   - pip install chainer==$CHAINER_VERSION
-  - pip install six==1.11.0
-  - pip install texttable==1.4.0
-  - pip install flake8==2.5.5
-  - pip install pytest==3.5.1
-  - pip install pytest-cov==2.5.1
-  - pip install coveralls==1.3.0
+  - pip install six==1.12.0
+  - pip install texttable==1.6.0
+  - pip install flake8==3.7.5
+  - pip install pytest==4.2.1
+  - pip install pytest-cov==2.6.1
+  - pip install coveralls==1.5.1
 script:
   - python -m pytest --cov chainer_computational_cost
   - flake8 .

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ However,
 
 ## Requirements
 
-* Python 2.7, 3.3, 3.4, 3.5, 3.6 and 3.7
-* Chainer 3.5, 4.4, 5.0.0rc1
-* six==1.11.0
+* Python 2.7, 3.5, 3.6 and 3.7
+* Chainer 4.x, 5.x and 6.0(beta)
+* six==1.12.0
 * (optional) texttable >= 1.4.0
-* (optional) pytest >= 3.5.1
+* (optional) pytest >= 4.2.1
 
 
 ## Installation

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(name='chainer_computational_cost',
       ],
       install_requires=[
           'chainer>=4.0.0',
-          'texttable>=1.2.0'
+          'texttable>=1.4.0'
       ],
       license='MIT')


### PR DESCRIPTION
Py 3.3 is already EOL, 3.4 is about to be, and chainer v3 is already old too.
Also dependent packages are continuously updated.
This PR is to exclude them.