### PR TITLE
Fixed sigmoid function (Fixes #17)

### DIFF
--- a/chainer_computational_cost/cost_calculators/activation.py
+++ b/chainer_computational_cost/cost_calculators/activation.py
@@ -84,7 +84,7 @@ def calc_sigmoid(func, in_data, **kwargs):
     | params | N/A |
     """
     x, = in_data
-    return (x.size, x.size, x.size, {})
+    return (4 * x.size, x.size, x.size, {})
 
 
 @register(Softmax)

--- a/tests/test_cost_calculators/test_activation.py
+++ b/tests/test_cost_calculators/test_activation.py
@@ -39,7 +39,7 @@ def test_activation_sigmoid():
     x = np.random.randn(1, 3, 100, 100).astype(np.float32)
     f = A.sigmoid.Sigmoid()
     flops, mread, mwrite, params = calculate_cost(f, [x])
-    assert flops == x.size
+    assert flops == 4 * x.size
     assert mread == x.size
     assert mwrite == x.size
     assert params == dict()


### PR DESCRIPTION
The document says "sigmoid function takes 4*input_size FLOPs" (and that is the case) but the code actually returned input size, as reported in #17. This PR fixes it.